### PR TITLE
Make copyright year dynamic

### DIFF
--- a/source/partials/_footer.slim
+++ b/source/partials/_footer.slim
@@ -59,7 +59,7 @@
   .Footer-credits
     span.Footer-handcrafted Handcrafted by
     span.Footer-subvisual SUBVISUAL
-    span.Footer-copyright © 2015 Copyright by Subvisual
+    span.Footer-copyright © #{Date.today.year} Copyright by Subvisual
   = link_to 'https://subvisual.co/hire-us', class: 'Footer-work'
     span.Footer-interested Interested in our services?
     .Footer-workText


### PR DESCRIPTION
Why:

* The copyright year is still set to 2015.

This change addresses the issue by:

* Making the copyright year dynamic, allowing us to update it
  automatically simply by re-deploying the code.